### PR TITLE
added mandarin textbook links 

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,8 @@
             <li><a href="https://github.com/espaspw/Resource-Guide/blob/master/doc/Guide%20to%20Learning%20Chinese.md">Guide to Learning Chinese</a></li>
             <li>《现代汉语八百词（增订本）》by 吕叔湘</li>
             <li><a href="https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401">New Practical Chinese Reader</a> - Progressively teaches reading, writing and listening.</li>
+            <li><a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.</li>
+            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
             <li><a href="https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit">Quick Starter Guide to Cantonese</a></li>
             <li><a href="https://drive.google.com/drive/folders/0BzQw-iJMJ8ygc1AzWWVZWmFPRVk?usp=sharing">Sietse’s Learning Pack</a></li>
             <li><a href="https://www.jyutping.org/en/docs/">Jyutping Guide</a> (with audio examples)</li>
@@ -770,6 +772,8 @@
             <li><a href="https://github.com/espaspw/Resource-Guide/blob/master/doc/Guide%20to%20Learning%20Chinese.md">Guide to Learning Chinese</a></li>
             <li>《现代汉语八百词（增订本）》by 吕叔湘</li>
             <li><a href="https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401">New Practical Chinese Reader</a> - Progressively teaches reading, writing and listening.</li>
+            <li><a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.</li>
+            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
             <li><a href="https://chinesepod.com/">Chinese Pod</a> [Lessons][Podcast] Requires free sign up.</li>
             <li><a href="http://kidschinesepodcast.com/lessons/">Kid’s Chinese Podcast</a> [Lessons][Podcast]</li>
             <li><a href="http://www.hellochinese.cc/">Hello Chinese</a> [Lessons][Vocab] - Gamification or Anki/SRS-like course</li>

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
             <li>《现代汉语八百词（增订本）》by 吕叔湘</li>
             <li><a href="https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401">New Practical Chinese Reader</a> - Progressively teaches reading, writing and listening.</li>
             <li><a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.</li>
-            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
+            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 (Jinan University) with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
             <li><a href="https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit">Quick Starter Guide to Cantonese</a></li>
             <li><a href="https://drive.google.com/drive/folders/0BzQw-iJMJ8ygc1AzWWVZWmFPRVk?usp=sharing">Sietse’s Learning Pack</a></li>
             <li><a href="https://www.jyutping.org/en/docs/">Jyutping Guide</a> (with audio examples)</li>
@@ -773,7 +773,7 @@
             <li>《现代汉语八百词（增订本）》by 吕叔湘</li>
             <li><a href="https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401">New Practical Chinese Reader</a> - Progressively teaches reading, writing and listening.</li>
             <li><a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.</li>
-            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
+            <li><a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 (Jinan University) with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.</li>
             <li><a href="https://chinesepod.com/">Chinese Pod</a> [Lessons][Podcast] Requires free sign up.</li>
             <li><a href="http://kidschinesepodcast.com/lessons/">Kid’s Chinese Podcast</a> [Lessons][Podcast]</li>
             <li><a href="http://www.hellochinese.cc/">Hello Chinese</a> [Lessons][Vocab] - Gamification or Anki/SRS-like course</li>

--- a/links.yaml
+++ b/links.yaml
@@ -86,6 +86,12 @@ Guides/Textbooks:
 - tags: ['Mandarin']
   body: '<a href="https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401">New Practical Chinese Reader</a> - Progressively teaches reading, writing and listening.'
 
+- tags: ['Mandarin']
+  body: '<a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.'
+
+- tags: ['Mandarin']
+  body: '<a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.'
+
 - tags: ['Cantonese']
   body: '<a href="https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit">Quick Starter Guide to Cantonese</a>'
 

--- a/links.yaml
+++ b/links.yaml
@@ -90,7 +90,7 @@ Guides/Textbooks:
   body: '<a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.'
 
 - tags: ['Mandarin']
-  body: '<a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.'
+  body: '<a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 (Jinan University) with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.'
 
 - tags: ['Cantonese']
   body: '<a href="https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit">Quick Starter Guide to Cantonese</a>'

--- a/resources.md
+++ b/resources.md
@@ -51,6 +51,8 @@ Mandarin and Cantonese lessons sections should be focused around getting a perso
 - [Guide to Learning Chinese](https://github.com/espaspw/Resource-Guide/blob/master/doc/Guide%20to%20Learning%20Chinese.md)
 - 《现代汉语八百词（增订本）》by 吕叔湘
 - [New Practical Chinese Reader](https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401) - Progressively teaches reading, writing and listening.
+- [學華語向前走 Let’s Learn Chinese](https://www.huayuworld.org/material-download.php) free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.
+- [《中文》](http://www.hwjyw.com/textbooks/downloads/zhongwen/) free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.
 - [Quick Starter Guide to Cantonese](https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit)
 - [Sietse’s Learning Pack](https://drive.google.com/drive/folders/0BzQw-iJMJ8ygc1AzWWVZWmFPRVk?usp=sharing)
 - [Jyutping Guide](https://www.jyutping.org/en/docs/) (with audio examples)

--- a/resources.md
+++ b/resources.md
@@ -52,7 +52,7 @@ Mandarin and Cantonese lessons sections should be focused around getting a perso
 - 《现代汉语八百词（增订本）》by 吕叔湘
 - [New Practical Chinese Reader](https://www.amazon.com/New-Practical-Chinese-Reader-Textbook/dp/7561910401) - Progressively teaches reading, writing and listening.
 - [學華語向前走 Let’s Learn Chinese](https://www.huayuworld.org/material-download.php) free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.
-- [《中文》](http://www.hwjyw.com/textbooks/downloads/zhongwen/) free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.
+- [《中文》](http://www.hwjyw.com/textbooks/downloads/zhongwen/) free downloads, published by 中国暨南大学 (Jinan University) with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.
 - [Quick Starter Guide to Cantonese](https://docs.google.com/document/d/1YCpiRPZbPei0PfaoZUTuesxoJ0TbTWryHM9GbtSM2ig/edit)
 - [Sietse’s Learning Pack](https://drive.google.com/drive/folders/0BzQw-iJMJ8ygc1AzWWVZWmFPRVk?usp=sharing)
 - [Jyutping Guide](https://www.jyutping.org/en/docs/) (with audio examples)


### PR DESCRIPTION
added links for free textbook downloads from 全球華文網 (huayuworld.org) and 中国华文教育网 (hwjyw.com)

```yaml
- tags: ['Mandarin']
  body: '<a href="https://www.huayuworld.org/material-download.php">學華語向前走 Let’s Learn Chinese</a> free downloads from 華文網, a website organized by the Overseas Community Affairs Council of Taiwan (僑委會), contains textbooks and resources for learning Mandarin with Traditional Chinese characters.'

- tags: ['Mandarin']
  body: '<a href="http://www.hwjyw.com/textbooks/downloads/zhongwen/">《中文》</a> free downloads, published by 中国暨南大学 with the cooperation of the Overseas Chinese Affairs Office (侨务办公室) of (mainland) China, contains textbooks for learning Mandarin with Simplified Chinese Characters.'
```